### PR TITLE
Improved question management interface, for 2.7+

### DIFF
--- a/ipal/classes/bank/search/condition_unused.php
+++ b/ipal/classes/bank/search/condition_unused.php
@@ -1,0 +1,76 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+
+/**
+ * Defines a class for filtering out used questions from the question bank.
+ *
+ * @package   mod_ipal
+ * @copyright 2015 Paul Nicholls
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace mod_ipal\bank\search;
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * A class for filtering out used questions from the question bank.
+ *
+ * See also {@link question_bank_view::init_search_conditions()}.
+ * @copyright 2015 Paul Nicholls
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class condition_unused extends \core_question\bank\search\condition {
+    /** @var Where clause to return. */
+    protected $where;
+
+    /** @var Array of parameters to return. */
+    protected $params;
+
+    /**
+     * Constructor.
+     * @param string $quiz quiz object containing questions to skip.
+     */
+    public function __construct($quiz) {
+        global $DB;
+        $skipqs = explode(",", $quiz->questions);
+        if (!empty($skipqs)) {
+            list($where, $params) = $DB->get_in_or_equal($skipqs, SQL_PARAMS_NAMED, 'skipq', false);
+            $this->where = 'q.id ' . $where;
+            $this->params = $params;
+        }
+    }
+
+    /**
+     * Return an SQL fragment to be ANDed into the WHERE clause to filter which questions are shown.
+     * @return string SQL fragment. Must use named parameters.
+     */
+    public function where() {
+        if (!empty($this->where)) {
+            return $this->where;
+        }
+    }
+
+    /**
+     * Return parameters to be bound to the above WHERE clause fragment.
+     * @return array parameter name => value.
+     */
+    public function params() {
+        if (!empty($this->params)) {
+            return $this->params;
+        }
+    }
+}

--- a/ipal/styles.css
+++ b/ipal/styles.css
@@ -1,0 +1,64 @@
+#page-mod-ipal-edit .questionbankwindow.block {
+    float: right;
+    width: 30%;
+    right: 0.3em;
+    padding-bottom: 0.5em;
+    display: block;
+    border-width: 0;
+}
+#page-mod-ipal-edit .questionbankwindow.block .content {
+    padding: 10px 5px;
+}
+#page-mod-ipal-edit .questionbankwindow .choosecategory,
+#page-mod-ipal-edit .questionbankwindow .createnewquestion {
+    padding: 0.3em;
+}
+#page-mod-ipal-edit .questionbankwindow .createnewquestion .singlebutton {
+    display: inline;
+}
+#page-mod-ipal-edit .questionbankwindow #catmenu_jump {
+    display: block;
+}
+
+#page-mod-ipal-edit .questionbankwindow.block th.questionnametext {
+    overflow:hidden;
+}
+
+#page-mod-ipal-edit .questionbankwindow select#catmenu_jump {
+/* In Opera9, IE6 the width of the
+select obeys the width of its content
+by default. This prevents that. */width: 100%;
+}
+
+/*this color might need to be theme-specific,
+but in terms of usability, as testing showed,
+http: //docs.moodle.org/dev/Quiz_UI_redesign/usability_testing_of_August_2008/Issues#Question_bank_.2F_question_adding_controls_visibility
+it must be ensured that the question
+bank window's title is prominent enough*/
+#page-mod-ipal-edit .questionbankwindow.block div.header {
+    background-color: #009;
+    background-image: none;
+    padding-top: 0.2em;
+    font-weight: bold;
+    border: 0 none;
+}
+#page-mod-ipal-edit .questionbankwindow.block div.header div.title h2 {
+    color: #FFF;
+    text-align: center;
+}
+#page-mod-ipal-edit .questionbankwindow.block div.bd > h2 {
+    display: none; /* Hide "Question bank" heading within block content. */
+}
+
+#page-mod-ipal-edit .questionbankwindow .createnewquestion select,
+#page-mod-ipal-edit .questionbankwindow #catmenu select,
+#page-mod-ipal-edit .questionbankwindow #menucategory {
+    width: 100%;
+}
+#page-mod-ipal-edit .questionbankwindow .modulespecificbuttonscontainer {
+    padding-top: 10px;
+}
+
+#page-mod-ipal-edit.dir-rtl .questionbankwindow.block {
+    float: left;
+}

--- a/ipal/version.php
+++ b/ipal/version.php
@@ -28,12 +28,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-if (!isset($plugin)) {
+if (!isset($plugin)){
     $plugin = new stdClass;
 }
-$plugin->version  = 2015031400;  // The current module version (Date: YYYYMMDDXX).
-$plugin->requires = 2014101500;  // Requires this Moodle version.
+$plugin->version  = 2015041500;  // The current module version (Date: YYYYMMDDXX).
+$plugin->requires = 2014051200;  // Requires this Moodle version.
 $plugin->cron     = 60;           // Period for cron to check this module (secs).
 $plugin->component = 'mod_ipal';      // To check on upgrade, that module sits in correct place.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.0.8 (Build: 2015031400';
+$plugin->release = '2.1.0 (Build: 2015041500';


### PR DESCRIPTION
Improved question management interface using the "fake block" question
bank from the quiz module in Moodle 2.7 and below - compatible with Moodle
2.7 and above (tested on 2.7 and 2.8).  Reduces the minimum Moodle version to 2.7 accordingly.

I've included a version bump to 2.1.0 - feel free to adjust this as desired.
