### PR TITLE
Make ComPADRE import and generic questions optional and tidy up analytics setting

### DIFF
--- a/ipal/db/upgrade.php
+++ b/ipal/db/upgrade.php
@@ -108,6 +108,17 @@ function xmldb_ipal_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2012081611, 'ipal');
     }
 
+    if ($oldversion < 2015041501) {
+        // Set renamed analytics config based on old one, if present.
+        $oldconfig = $DB->get_record('config', array('name'=>'ipal_analytics'));
+        if ($oldconfig !== false) {
+            set_config('analytics', $oldconfig->value, 'mod_ipal');
+        }
+
+        // Ipal savepoint reached.
+        upgrade_mod_savepoint(true, 2015041501, 'ipal');
+    }
+
     // Final return of upgrade result (true, all went good) to Moodle.
     return true;
 }

--- a/ipal/edit.php
+++ b/ipal/edit.php
@@ -225,7 +225,9 @@ $condition = new mod_ipal\bank\search\condition_unused($quiz);
 $questionbank->add_searchcondition($condition);
 
 echo '<div class="questionbankwindow block">';
-ipal_create_genericq($quiz->course);
+if (!empty(get_config('mod_ipal', 'autocreate_generic'))) {
+    ipal_create_genericq($quiz->course);
+}
 echo '<div class="header"><div class="title">';
 echo "<h2>Add Questions</h2>";
 echo "</div></div>";

--- a/ipal/edit.php
+++ b/ipal/edit.php
@@ -230,7 +230,10 @@ echo '<div class="header"><div class="title">';
 echo "<h2>Add Questions</h2>";
 echo "</div></div>";
 echo '<div class="content"><div class="box generalbox questionbank">';
-require_once($CFG->dirroot . '/mod/ipal/quiz/compadre_access_form.php');
+if (!empty(get_config('mod_ipal', 'enable_compadre'))) {
+    // Include the ComPADRE question import form if enabled.
+    require_once($CFG->dirroot . '/mod/ipal/quiz/compadre_access_form.php');
+}
 if ($DB->count_records('modules', array('name' => 'ejsapp'))) {
     echo "\nClick <a href='".$CFG->wwwroot."/mod/ipal/ejs_ipal.php?cmid=$cmid'>
         to add EJS Apps</a>";

--- a/ipal/lang/en/ipal.php
+++ b/ipal/lang/en/ipal.php
@@ -85,3 +85,9 @@ $string['ipal_analytics_help'] = 'If this is selected the student polling data, 
      Only authorized people at your institution can access the data and identify the user names or actual names of any student.
      and these authorized people can only view the results of the analysis for their own school.
      <br />If this is not selected, no data is sent to the ComPADRE site.';
+
+$string['ipal_enable_compadre'] = 'Enable retrieval of questions from ComPADRE';
+$string['ipal_enable_compadre_help'] = 'If this is selected, the teacher can choose to import ready-to-use peer-reviewed questions.
+	 The initial set of questions includes hundreds of introductory physics questions from the ConcepTest questions, authored
+	 by Physics Professor Eric Mazur and his group from Harvard University. These questions are housed at <a href="http://www.compadre.org/" target="_blank">ComPADRE</a>, a National
+	 Physics and Astronomy Digital Library.';

--- a/ipal/lang/en/ipal.php
+++ b/ipal/lang/en/ipal.php
@@ -91,3 +91,7 @@ $string['ipal_enable_compadre_help'] = 'If this is selected, the teacher can cho
 	 The initial set of questions includes hundreds of introductory physics questions from the ConcepTest questions, authored
 	 by Physics Professor Eric Mazur and his group from Harvard University. These questions are housed at <a href="http://www.compadre.org/" target="_blank">ComPADRE</a>, a National
 	 Physics and Astronomy Digital Library.';
+
+$string['ipal_autocreate_generic'] = 'Auto-create generic questions';
+$string['ipal_autocreate_generic_help'] = 'If this is selected, generic multichoice and essay questions will be automatically created when the teacher first chooses to select
+	 the questions for an IPAL instance.';

--- a/ipal/settings.php
+++ b/ipal/settings.php
@@ -34,7 +34,7 @@ defined('MOODLE_INTERNAL') || die;
 
 $name = new lang_string('ipal_analytics', 'mod_ipal');
 $description = new lang_string('ipal_analytics_help', 'mod_ipal');
-$settings->add(new admin_setting_configcheckbox('ipal_analytics',
+$settings->add(new admin_setting_configcheckbox('mod_ipal/analytics',
                                                 $name,
                                                 $description,
                                                 1));

--- a/ipal/settings.php
+++ b/ipal/settings.php
@@ -45,3 +45,10 @@ $settings->add(new admin_setting_configcheckbox('mod_ipal/enable_compadre',
                                                 $name,
                                                 $description,
                                                 1));
+
+$name = new lang_string('ipal_autocreate_generic', 'mod_ipal');
+$description = new lang_string('ipal_autocreate_generic_help', 'mod_ipal');
+$settings->add(new admin_setting_configcheckbox('mod_ipal/autocreate_generic',
+                                                $name,
+                                                $description,
+                                                1));

--- a/ipal/settings.php
+++ b/ipal/settings.php
@@ -38,3 +38,10 @@ $settings->add(new admin_setting_configcheckbox('ipal_analytics',
                                                 $name,
                                                 $description,
                                                 1));
+
+$name = new lang_string('ipal_enable_compadre', 'mod_ipal');
+$description = new lang_string('ipal_enable_compadre_help', 'mod_ipal');
+$settings->add(new admin_setting_configcheckbox('mod_ipal/enable_compadre',
+                                                $name,
+                                                $description,
+                                                1));

--- a/ipal/version.php
+++ b/ipal/version.php
@@ -31,9 +31,9 @@ defined('MOODLE_INTERNAL') || die();
 if (!isset($plugin)){
     $plugin = new stdClass;
 }
-$plugin->version  = 2015041500;  // The current module version (Date: YYYYMMDDXX).
+$plugin->version  = 2015041501;  // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2014051200;  // Requires this Moodle version.
 $plugin->cron     = 60;           // Period for cron to check this module (secs).
 $plugin->component = 'mod_ipal';      // To check on upgrade, that module sits in correct place.
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '2.1.0 (Build: 2015041500';
+$plugin->release = '2.1.1 (Build: 2015041501)';


### PR DESCRIPTION
Make the ComPADRE import function and generic question creation optional at the site level via new config options, and convert the analytics setting to plugin config (from site config).
