### PR TITLE
Ignore multiple records in findinstructor()

### DIFF
--- a/ipal/locallib.php
+++ b/ipal/locallib.php
@@ -724,7 +724,7 @@ function findinstructor($cnum) {
             ro.shortname='editingteacher' AND r.roleid =ro.id AND
             c.id = ? AND cx.contextlevel =50";
     // The variable $cnum is the id number for the course in the course table.
-    $result = $DB->get_record_sql($query, array($cnum));
+    $result = $DB->get_record_sql($query, array($cnum), IGNORE_MULTIPLE);
     if (!$result) {
         return('none');
     } else {


### PR DESCRIPTION
The call to $DB->get_record_sql() in findinstructor() was generating an
error when there is more than one editing teacher in the course.  This is
a quick workaround - setting the IGNORE_MULTIPLE flag so that the first
matching record is returned with no error.  It may be desirable to rework
this function to pick from multiple teachers in a smarter way.
